### PR TITLE
Increase curl timeout parameter

### DIFF
--- a/HttpClient.php
+++ b/HttpClient.php
@@ -31,7 +31,7 @@ class HttpClient
         $ch = curl_init($this->url);
         curl_setopt_array($ch, array(
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_TIMEOUT => 5,
+            CURLOPT_TIMEOUT => 30,
         ));
 
         $response = curl_exec($ch);


### PR DESCRIPTION
I increased the timeout parameter to 30 seconds for cases where 5 seconds are not enough. 