### PR TITLE
Fixed error when api returns null result

### DIFF
--- a/src/ResultDecoder.php
+++ b/src/ResultDecoder.php
@@ -165,9 +165,12 @@ class ResultDecoder
         if (isset($results['symbol'])) {
             return [$this->createQuote($results)];
         } else {
-            return array_map(function ($item) {
-                return $this->createQuote($item);
-            }, $results);
+            if (is_array($results)) {
+                return array_map(function ($item) {
+                    return $this->createQuote($item);
+                }, $results);
+            }
+            throw new ApiException('Yahoo Search API return null result', ApiException::INVALID_VALUE);
         }
     }
 


### PR DESCRIPTION
Today Yahoo Finance Api returns null result from yahoo.finance.* table, so in method `transformQuotes` in `array_map` function second parameter is null but must be an array.