### PR TITLE
Use of DateTimeInterface instead of DateTime

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -58,7 +58,7 @@ class ApiClient
      *
      * @throws ApiException
      */
-    public function getHistoricalData(string $symbol, string $interval, \DateTime $startDate, \DateTime $endDate): array
+    public function getHistoricalData(string $symbol, string $interval, \DateTimeInterface $startDate, \DateTimeInterface $endDate): array
     {
         $allowedIntervals = [self::INTERVAL_1_DAY, self::INTERVAL_1_WEEK, self::INTERVAL_1_MONTH];
         if (!\in_array($interval, $allowedIntervals)) {

--- a/src/Results/HistoricalData.php
+++ b/src/Results/HistoricalData.php
@@ -30,7 +30,7 @@ class HistoricalData implements \JsonSerializable
         return get_object_vars($this);
     }
 
-    public function getDate(): \DateTime
+    public function getDate(): \DateTimeInterface
     {
         return $this->date;
     }

--- a/src/Results/Quote.php
+++ b/src/Results/Quote.php
@@ -129,22 +129,22 @@ class Quote implements \JsonSerializable
         return $this->currency;
     }
 
-    public function getDividendDate(): ?\DateTime
+    public function getDividendDate(): ?\DateTimeInterface
     {
         return $this->dividendDate;
     }
 
-    public function getEarningsTimestamp(): ?\DateTime
+    public function getEarningsTimestamp(): ?\DateTimeInterface
     {
         return $this->earningsTimestamp;
     }
 
-    public function getEarningsTimestampStart(): ?\DateTime
+    public function getEarningsTimestampStart(): ?\DateTimeInterface
     {
         return $this->earningsTimestampStart;
     }
 
-    public function getEarningsTimestampEnd(): ?\DateTime
+    public function getEarningsTimestampEnd(): ?\DateTimeInterface
     {
         return $this->earningsTimestampEnd;
     }
@@ -289,7 +289,7 @@ class Quote implements \JsonSerializable
         return $this->postMarketPrice;
     }
 
-    public function getPostMarketTime(): ?\DateTime
+    public function getPostMarketTime(): ?\DateTimeInterface
     {
         return $this->postMarketTime;
     }
@@ -309,7 +309,7 @@ class Quote implements \JsonSerializable
         return $this->preMarketPrice;
     }
 
-    public function getPreMarketTime(): ?\DateTime
+    public function getPreMarketTime(): ?\DateTimeInterface
     {
         return $this->preMarketTime;
     }
@@ -374,7 +374,7 @@ class Quote implements \JsonSerializable
         return $this->regularMarketPrice;
     }
 
-    public function getRegularMarketTime(): ?\DateTime
+    public function getRegularMarketTime(): ?\DateTimeInterface
     {
         return $this->regularMarketTime;
     }

--- a/src/ValueMapper.php
+++ b/src/ValueMapper.php
@@ -70,7 +70,7 @@ class ValueMapper implements ValueMapperInterface
     /**
      * @param mixed $rawValue
      */
-    private function mapDateValue($rawValue): \DateTime
+    private function mapDateValue($rawValue): \DateTimeInterface
     {
         try {
             return new \DateTime('@'.$rawValue);


### PR DESCRIPTION
With this PR, the DateTimeInterface is used instead of DateTime as return type or argument.
This will allow to use DateTimeImmutable or the DateTime objects from [PHP Safe library](https://github.com/thecodingmachine/safe).