### PR TITLE
Added possibility to search in other regions

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -47,11 +47,15 @@ class ApiClient
      *
      * @throws ApiException
      */
-    public function search(string $searchTerm): array
+    public function search(string $searchTerm, string $locale = 'en-US'): array
     {
-        $url = 'https://finance.yahoo.com/_finance_doubledown/api/resource/searchassist;gossipConfig=%7B%22queryKey%22:%22query%22,%22resultAccessor%22:%22ResultSet.Result%22,%22suggestionTitleAccessor%22:%22symbol%22,%22suggestionMeta%22:[%22symbol%22],%22url%22:%7B%22query%22:%7B%22region%22:%22US%22,%22lang%22:%22en-US%22%7D%7D%7D;searchTerm='
+        $url = 'https://finance.yahoo.com/_finance_doubledown/api/resource/searchassist;gossipConfig=%7B%22queryKey%22:%22query%22,%22resultAccessor%22:%22ResultSet.Result%22,%22suggestionTitleAccessor%22:%22symbol%22,%22suggestionMeta%22:[%22symbol%22],%22url%22:%7B%22query%22:%7B%22region%22:%22US%22,%22lang%22:%22'
+            .urlencode($locale)
+            .'%22%7D%7D%7D;searchTerm='
             .urlencode($searchTerm)
-            .'?bkt=[%22findd-ctrl%22,%22fin-strm-test1%22,%22fndmtest%22,%22finnossl%22]&device=desktop&feature=canvassOffnet,finGrayNav,newContentAttribution,relatedVideoFeature,videoNativePlaylist,livecoverage&intl=us&lang=en-US&partner=none&prid=eo2okrhcni00f&region=US&site=finance&tz=UTC&ver=0.102.432&returnMeta=true';
+            .'?bkt=[%22findd-ctrl%22,%22fin-strm-test1%22,%22fndmtest%22,%22finnossl%22]&device=desktop&feature=canvassOffnet,finGrayNav,newContentAttribution,relatedVideoFeature,videoNativePlaylist,livecoverage&intl=us&lang='
+            .urlencode($locale)
+            .'&partner=none&prid=eo2okrhcni00f&region=DE&site=finance&tz=UTC&ver=0.102.432&returnMeta=true';
         $responseBody = (string) $this->client->request('GET', $url)->getBody();
 
         return $this->resultDecoder->transformSearchResult($responseBody);

--- a/tests/ApiClientIntegrationTest.php
+++ b/tests/ApiClientIntegrationTest.php
@@ -18,12 +18,16 @@ class ApiClientIntegrationTest extends TestCase
 {
     private const APPLE_NAME = 'Apple';
     private const APPLE_SYMBOL = 'AAPL';
+    private const APPLE_SYMBOL_FRANKFURT = 'APC.F';
     private const GOOGLE_SYMBOL = 'GOOG';
 
     private const CURRENCY_USD = 'USD';
     private const CURRENCY_EUR = 'EUR';
     private const TRY_COUNT = 3;
     private const RETRY_SLEEP_SECONDS = 1;
+
+    private const REGION_US = 'en_US';
+    private const REGION_GERMANY = 'de_DE';
 
     /**
      * @var ApiClient
@@ -45,7 +49,7 @@ class ApiClientIntegrationTest extends TestCase
         $this->assertIsArray($returnValue);
         $this->assertContainsOnlyInstancesOf(SearchResult::class, $returnValue);
 
-        $aaplStock = $this->findAAPL($returnValue);
+        $aaplStock = $this->findApple($returnValue);
         $this->assertNotNull($aaplStock, 'Search result must contain AAPL');
 
         $this->assertEquals('Apple Inc.', $aaplStock->getName());
@@ -64,12 +68,37 @@ class ApiClientIntegrationTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function search_withSearchTermAndRegion_returnSearchResults(): void
+    {
+        $returnValue = $this->client->search(self::APPLE_NAME, self::REGION_GERMANY);
+
+        $this->assertIsArray($returnValue);
+        $this->assertContainsOnlyInstancesOf(SearchResult::class, $returnValue);
+
+        $aaplStock = $this->findApple($returnValue, self::APPLE_SYMBOL_FRANKFURT);
+        $this->assertNotNull($aaplStock, 'Search result must contain APC.F');
+
+        $this->assertEquals('Apple Inc.', $aaplStock->getName());
+        $this->assertEquals('S', $aaplStock->getType());
+        $this->assertEquals('Frankfurt', $aaplStock->getExchDisp());
+        $this->assertEquals('Aktie', $aaplStock->getTypeDisp());
+
+        // Can be either NAS or NMS
+        $this->assertThat(
+            $aaplStock->getExch(),
+            $this->equalTo('FRA'),
+        );
+    }
+
+    /**
      * @param SearchResult[] $searchResult
      */
-    private function findAAPL($searchResult): ?SearchResult
+    private function findApple($searchResult, $symbol = self::APPLE_SYMBOL): ?SearchResult
     {
         foreach ($searchResult as $result) {
-            if (self::APPLE_SYMBOL === $result->getSymbol()) {
+            if ($symbol === $result->getSymbol()) {
                 return $result;
             }
         }

--- a/tests/ApiClientIntegrationTest.php
+++ b/tests/ApiClientIntegrationTest.php
@@ -88,7 +88,7 @@ class ApiClientIntegrationTest extends TestCase
         // Can be either NAS or NMS
         $this->assertThat(
             $aaplStock->getExch(),
-            $this->equalTo('FRA'),
+            $this->equalTo('FRA')
         );
     }
 


### PR DESCRIPTION
**Description**
We need to search for searchTerms in other regions than only the US. You can provide a region to the Yahoo Finance API in order to get other results. Added a possibility to specify a region but did not break any logic.
