### PR TITLE
Feature/add stock options functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ $quote = $client->getQuote("AAPL");
 
 // Returns an array of Scheb\YahooFinanceApi\Results\Quote
 $quotes = $client->getQuotes(["AAPL", "GOOG"]);
+
+// Returns an array of Scheb\YahooFinanceApi\Results\OptionChain
+$optionChain = $client->getOptionChain("AAPL");
+$optionChain = $client->getOptionChain("AAPL", new \DateTime("2021-01-01"));
 ```
 
 Version Guidance

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -287,7 +287,7 @@ class ApiClient
         return $this->resultDecoder->transformQuotesSummary($responseBody);
     }
 
-    public function getStockOptions(string $symbol, ?\DateTimeInterface $expiryDate = null): array
+    public function getOptionChain(string $symbol, ?\DateTimeInterface $expiryDate = null): array
     {
         $qs = $this->getRandomQueryServer();
 
@@ -304,6 +304,6 @@ class ApiClient
         }
         $responseBody = (string) $this->client->request('GET', $url, ['cookies' => $cookieJar, 'headers' => $this->getHeaders()])->getBody();
 
-        return $this->resultDecoder->transformOptions($responseBody);
+        return $this->resultDecoder->transformOptionChains($responseBody);
     }
 }

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -285,6 +285,25 @@ class ApiClient
         $responseBody = (string) $this->client->request('GET', $url, ['cookies' => $cookieJar, 'headers' => $this->getHeaders()])->getBody();
 
         return $this->resultDecoder->transformQuotesSummary($responseBody);
+    }
 
+    public function getStockOptions(string $symbol, ?\DateTimeInterface $expiryDate = null): array
+    {
+        $qs = $this->getRandomQueryServer();
+
+        // Initialize session cookies
+        $cookieJar = $this->getCookies();
+
+        // Get crumb value
+        $crumb = $this->getCrumb($qs, $cookieJar);
+
+        // Fetch options
+        $url = 'https://query'.$qs.'.finance.yahoo.com/v7/finance/options/'.$symbol.'?crumb='.$crumb;
+        if ($expiryDate) {
+            $url .= '&date='.(string) $expiryDate->getTimestamp();
+        }
+        $responseBody = (string) $this->client->request('GET', $url, ['cookies' => $cookieJar, 'headers' => $this->getHeaders()])->getBody();
+
+        return $this->resultDecoder->transformOptions($responseBody);
     }
 }

--- a/src/ResultDecoder.php
+++ b/src/ResultDecoder.php
@@ -273,7 +273,7 @@ class ResultDecoder
         return new Quote($mappedValues);
     }
 
-    public function transformQuotesSumamary(string $responseBody): array
+    public function transformQuotesSummary(string $responseBody): array
     {
         $decoded = json_decode($responseBody, true);
         if (!isset($decoded['quoteSummary']['result']) || !\is_array($decoded['quoteSummary']['result'])) {
@@ -282,4 +282,5 @@ class ResultDecoder
 
         return $decoded['quoteSummary']['result'];
     }
+
 }

--- a/src/Results/Option.php
+++ b/src/Results/Option.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\YahooFinanceApi\Results;
+
+class Option implements \JsonSerializable
+{
+    private $contractSymbol;
+    private $strike;
+    private $currency;
+    private $lastPrice;
+    private $change;
+    private $percentChange;
+    private $volume;
+    private $openInterest;
+    private $bid;
+    private $ask;
+    private $contractSize;
+    private $expiration;
+    private $lastTradeDate;
+    private $impliedVolatility;
+    private $inTheMoney;
+
+    public function __construct(array $values)
+    {
+        foreach ($values as $property => $value) {
+            $this->{$property} = $value;
+        }
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+
+    public function getContractSymbol(): string
+    {
+        return $this->contractSymbol;
+    }
+
+    public function getStrike(): float
+    {
+        return $this->strike;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function getLastPrice(): float
+    {
+        return $this->lastPrice;
+    }
+
+    public function getChange(): float
+    {
+        return $this->change;
+    }
+
+    public function getPercentChange(): float
+    {
+        return $this->percentChange;
+    }
+
+    public function getVolume(): int
+    {
+        return $this->volume;
+    }
+
+    public function getOpenInterest(): int
+    {
+        return $this->openInterest;
+    }
+
+    public function getBid(): float
+    {
+        return $this->bid;
+    }
+
+    public function getAsk(): float
+    {
+        return $this->ask;
+    }
+
+    public function getContractSize(): string
+    {
+        return $this->contractSize;
+    }
+
+    public function getExpiration(): \DateTimeInterface
+    {
+        return $this->expiration;
+    }
+
+    public function getLastTradeDate(): \DateTimeInterface
+    {
+        return $this->lastTradeDate;
+    }
+
+    public function getImpliedVolatility(): float
+    {
+        return $this->impliedVolatility;
+    }
+
+    public function getInTheMoney(): bool
+    {
+        return $this->inTheMoney;
+    }
+}

--- a/src/Results/Option.php
+++ b/src/Results/Option.php
@@ -6,21 +6,10 @@ namespace Scheb\YahooFinanceApi\Results;
 
 class Option implements \JsonSerializable
 {
-    private $contractSymbol;
-    private $strike;
-    private $currency;
-    private $lastPrice;
-    private $change;
-    private $percentChange;
-    private $volume;
-    private $openInterest;
-    private $bid;
-    private $ask;
-    private $contractSize;
-    private $expiration;
-    private $lastTradeDate;
-    private $impliedVolatility;
-    private $inTheMoney;
+    private $expirationDate;
+    private $hasMiniOptions;
+    private $calls;
+    private $puts;
 
     public function __construct(array $values)
     {
@@ -31,81 +20,35 @@ class Option implements \JsonSerializable
 
     public function jsonSerialize(): array
     {
-        return get_object_vars($this);
+        return [
+            'expirationDate' => $this->expirationDate,
+            'hasMiniOptions' => $this->hasMiniOptions,
+            'calls' => array_map(function (OptionContract $optionContract): array {
+                return $optionContract->jsonSerialize();
+            }, $this->calls),
+            'puts' => array_map(function (OptionContract $optionContract): array {
+                return $optionContract->jsonSerialize();
+            }, $this->puts),
+        ];
     }
 
-    public function getContractSymbol(): string
+    public function getExpirationDate(): int
     {
-        return $this->contractSymbol;
+        return $this->expirationDate;
     }
 
-    public function getStrike(): float
+    public function getHasMiniOptions(): bool
     {
-        return $this->strike;
+        return $this->hasMiniOptions;
     }
 
-    public function getCurrency(): string
+    public function getCalls(): array
     {
-        return $this->currency;
+        return $this->calls;
     }
 
-    public function getLastPrice(): float
+    public function getPuts(): array
     {
-        return $this->lastPrice;
-    }
-
-    public function getChange(): float
-    {
-        return $this->change;
-    }
-
-    public function getPercentChange(): float
-    {
-        return $this->percentChange;
-    }
-
-    public function getVolume(): int
-    {
-        return $this->volume;
-    }
-
-    public function getOpenInterest(): int
-    {
-        return $this->openInterest;
-    }
-
-    public function getBid(): float
-    {
-        return $this->bid;
-    }
-
-    public function getAsk(): float
-    {
-        return $this->ask;
-    }
-
-    public function getContractSize(): string
-    {
-        return $this->contractSize;
-    }
-
-    public function getExpiration(): \DateTimeInterface
-    {
-        return $this->expiration;
-    }
-
-    public function getLastTradeDate(): \DateTimeInterface
-    {
-        return $this->lastTradeDate;
-    }
-
-    public function getImpliedVolatility(): float
-    {
-        return $this->impliedVolatility;
-    }
-
-    public function getInTheMoney(): bool
-    {
-        return $this->inTheMoney;
+        return $this->puts;
     }
 }

--- a/src/Results/OptionChain.php
+++ b/src/Results/OptionChain.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\YahooFinanceApi\Results;
+
+class OptionChain implements \JsonSerializable
+{
+    private $underlyingSymbol;
+    private $expirationDates;
+    private $strikes;
+    private $hasMiniOptions;
+    private $options;
+
+    public function __construct(array $values)
+    {
+        foreach ($values as $property => $value) {
+            $this->{$property} = $value;
+        }
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'underlyingSymbol' => $this->underlyingSymbol,
+            'expirationDates' => $this->expirationDates,
+            'strikes' => $this->strikes,
+            'hasMiniOptions' => $this->hasMiniOptions,
+            'options' => array_map(function (Option $option): array {
+                return $option->jsonSerialize();
+            }, $this->options),
+        ];
+    }
+
+    public function getUnderlyingSymbol(): string
+    {
+        return $this->underlyingSymbol;
+    }
+
+    public function getExpirationDates(): array
+    {
+        return $this->expirationDates;
+    }
+
+    public function getStrikes(): array
+    {
+        return $this->strikes;
+    }
+
+    public function getHasMiniOptions(): bool
+    {
+        return $this->hasMiniOptions;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Results/OptionContract.php
+++ b/src/Results/OptionContract.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scheb\YahooFinanceApi\Results;
+
+class OptionContract implements \JsonSerializable
+{
+    private $contractSymbol;
+    private $strike;
+    private $currency;
+    private $lastPrice;
+    private $change;
+    private $percentChange;
+    private $volume;
+    private $openInterest;
+    private $bid;
+    private $ask;
+    private $contractSize;
+    private $expiration;
+    private $lastTradeDate;
+    private $impliedVolatility;
+    private $inTheMoney;
+
+    public function __construct(array $values)
+    {
+        foreach ($values as $property => $value) {
+            $this->{$property} = $value;
+        }
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+
+    public function getContractSymbol(): string
+    {
+        return $this->contractSymbol;
+    }
+
+    public function getStrike(): float
+    {
+        return $this->strike;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function getLastPrice(): float
+    {
+        return $this->lastPrice;
+    }
+
+    public function getChange(): float
+    {
+        return $this->change;
+    }
+
+    public function getPercentChange(): float
+    {
+        return $this->percentChange;
+    }
+
+    public function getVolume(): int
+    {
+        return $this->volume;
+    }
+
+    public function getOpenInterest(): int
+    {
+        return $this->openInterest;
+    }
+
+    public function getBid(): float
+    {
+        return $this->bid;
+    }
+
+    public function getAsk(): float
+    {
+        return $this->ask;
+    }
+
+    public function getContractSize(): string
+    {
+        return $this->contractSize;
+    }
+
+    public function getExpiration(): \DateTimeInterface
+    {
+        return $this->expiration;
+    }
+
+    public function getLastTradeDate(): \DateTimeInterface
+    {
+        return $this->lastTradeDate;
+    }
+
+    public function getImpliedVolatility(): float
+    {
+        return $this->impliedVolatility;
+    }
+
+    public function getInTheMoney(): bool
+    {
+        return $this->inTheMoney;
+    }
+}

--- a/src/ValueMapperInterface.php
+++ b/src/ValueMapperInterface.php
@@ -6,16 +6,20 @@ namespace Scheb\YahooFinanceApi;
 
 interface ValueMapperInterface
 {
+    public const TYPE_ARRAY = 'array';
+    public const TYPE_OBJECT = 'object';
     public const TYPE_FLOAT = 'float';
     public const TYPE_INT = 'int';
     public const TYPE_DATE = 'date';
     public const TYPE_STRING = 'string';
     public const TYPE_BOOL = 'bool';
 
+    public function mapArray(array $rawValue, string $type): array;
+
     /**
      * @param mixed $rawValue
      *
      * @return mixed
      */
-    public function mapValue($rawValue, string $type);
+    public function mapValue($rawValue, string $type, ?string $subType = null);
 }

--- a/tests/ApiClientIntegrationTest.php
+++ b/tests/ApiClientIntegrationTest.php
@@ -10,6 +10,7 @@ use Scheb\YahooFinanceApi\ApiClient;
 use Scheb\YahooFinanceApi\ApiClientFactory;
 use Scheb\YahooFinanceApi\Results\DividendData;
 use Scheb\YahooFinanceApi\Results\HistoricalData;
+use Scheb\YahooFinanceApi\Results\Option;
 use Scheb\YahooFinanceApi\Results\Quote;
 use Scheb\YahooFinanceApi\Results\SearchResult;
 use Scheb\YahooFinanceApi\Results\SplitData;
@@ -317,4 +318,12 @@ class ApiClientIntegrationTest extends TestCase
         $this->assertEquals(self::APPLE_SYMBOL, $returnValue[0]['quoteType']['symbol']);
     }
 
+    public function testGetStockOptions(): void
+    {
+        $returnValue = $this->client->getStockOptions(self::APPLE_SYMBOL);
+
+        $this->assertIsArray($returnValue);
+        $this->assertGreaterThan(0, \count($returnValue));
+        $this->assertContainsOnlyInstancesOf(Option::class, $returnValue);
+    }
 }

--- a/tests/ApiClientIntegrationTest.php
+++ b/tests/ApiClientIntegrationTest.php
@@ -309,11 +309,12 @@ class ApiClientIntegrationTest extends TestCase
         }
     }
 
-    public function testStockSummary()
+    public function testStockSummary(): void
     {
         $returnValue = $this->client->stockSummary(self::APPLE_SYMBOL);
 
         $this->assertIsArray($returnValue);
         $this->assertEquals(self::APPLE_SYMBOL, $returnValue[0]['quoteType']['symbol']);
     }
+
 }

--- a/tests/fixtures/invalidArrayOption.json
+++ b/tests/fixtures/invalidArrayOption.json
@@ -1,0 +1,47 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1711065600,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": 1711065600,
+            "hasMiniOptions": false,
+            "calls": "",
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidArrayOptionChain.json
+++ b/tests/fixtures/invalidArrayOptionChain.json
@@ -1,0 +1,22 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1711065600,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": "invalid_array"
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidBooleanOption.json
+++ b/tests/fixtures/invalidBooleanOption.json
@@ -1,0 +1,65 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1711065600,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": 1711065600,
+            "hasMiniOptions": "invalid_boolean",
+            "calls": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 256.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ],
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": "invalid_boolean"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidBooleanOptionChain.json
+++ b/tests/fixtures/invalidBooleanOptionChain.json
@@ -1,0 +1,65 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1711065600,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": "invalid_boolean",
+        "options": [
+          {
+            "expirationDate": 1711065600,
+            "hasMiniOptions": false,
+            "calls": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 256.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ],
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": "invalid_boolean"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidBooleanOptionContract.json
+++ b/tests/fixtures/invalidBooleanOptionContract.json
@@ -1,0 +1,65 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1711065600,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": 1711065600,
+            "hasMiniOptions": false,
+            "calls": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 256.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ],
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": "invalid_boolean"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidDateTimeOption.json
+++ b/tests/fixtures/invalidDateTimeOption.json
@@ -1,0 +1,65 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1700541200,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": "invalid_date_time",
+            "hasMiniOptions": false,
+            "calls": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 256.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": "invalid_date_time",
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ],
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidDateTimeOptionChain.json
+++ b/tests/fixtures/invalidDateTimeOptionChain.json
@@ -1,0 +1,65 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          "invalid_date_time",
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": 1711065600,
+            "hasMiniOptions": false,
+            "calls": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 256.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": "invalid_date_time",
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ],
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidDateTimeOptionContract.json
+++ b/tests/fixtures/invalidDateTimeOptionContract.json
@@ -1,0 +1,65 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1711065600,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": 1711065600,
+            "hasMiniOptions": false,
+            "calls": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 256.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": "invalid_date_time",
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ],
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidFloatOptionChain.json
+++ b/tests/fixtures/invalidFloatOptionChain.json
@@ -1,0 +1,65 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1711065600,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          "invalid_float",
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": 1711065600,
+            "hasMiniOptions": false,
+            "calls": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 256.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": "7.7744565%",
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ],
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/invalidFloatOptionContract.json
+++ b/tests/fixtures/invalidFloatOptionContract.json
@@ -1,0 +1,65 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": "AAPL",
+        "expirationDates": [
+          1711065600,
+          1711584000,
+          1781740800
+        ],
+        "strikes": [
+          100.0,
+          105.0,
+          265.0
+        ],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": 1711065600,
+            "hasMiniOptions": false,
+            "calls": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 256.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": "7.7744565%",
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ],
+            "puts": [
+              {
+                "contractSymbol": "AAPL240322P00265000",
+                "strike": 265.0,
+                "currency": "USD",
+                "lastPrice": 93.65,
+                "change": 6.7699966,
+                "percentChange": 7.7744565,
+                "volume": 3,
+                "openInterest": 0,
+                "bid": 90.65,
+                "ask": 94.8,
+                "contractSize": "REGULAR",
+                "expiration": 1598590800,
+                "lastTradeDate": 1597899600,
+                "impliedVolatility": 1.642579912109375,
+                "inTheMoney": false
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/nullOptionChain.json
+++ b/tests/fixtures/nullOptionChain.json
@@ -1,0 +1,21 @@
+{
+  "optionChain": {
+    "result": [
+      {
+        "underlyingSymbol": null,
+        "expirationDates": [],
+        "strikes": [],
+        "hasMiniOptions": false,
+        "options": [
+          {
+            "expirationDate": null,
+            "hasMiniOptions": false,
+            "calls": [],
+            "puts": []
+          }
+        ]
+      }
+    ],
+    "error": null
+  }
+}

--- a/tests/fixtures/optionChain.json
+++ b/tests/fixtures/optionChain.json
@@ -1,0 +1,65 @@
+{
+    "optionChain": {
+        "result": [
+            {
+                "underlyingSymbol": "AAPL",
+                "expirationDates": [
+                    1711065600,
+                    1711584000,
+                    1781740800
+                ],
+                "strikes": [
+                    100.0,
+                    105.0,
+                    265.0
+                ],
+                "hasMiniOptions": false,
+                "options": [
+                    {
+                        "expirationDate": 1711065600,
+                        "hasMiniOptions": false,
+                        "calls": [
+                            {
+                                "contractSymbol": "AAPL240322P00265000",
+                                "strike": 256.0,
+                                "currency": "USD",
+                                "lastPrice": 93.65,
+                                "change": 6.7699966,
+                                "percentChange": 7.7744565,
+                                "volume": 3,
+                                "openInterest": 0,
+                                "bid": 90.65,
+                                "ask": 94.8,
+                                "contractSize": "REGULAR",
+                                "expiration": 1598590800,
+                                "lastTradeDate": 1597899600,
+                                "impliedVolatility": 1.642579912109375,
+                                "inTheMoney": false
+                            }
+                        ],
+                        "puts": [
+                            {
+                                "contractSymbol": "AAPL240322P00265000",
+                                "strike": 265.0,
+                                "currency": "USD",
+                                "lastPrice": 93.65,
+                                "change": 6.7699966,
+                                "percentChange": 7.7744565,
+                                "volume": 3,
+                                "openInterest": 0,
+                                "bid": 90.65,
+                                "ask": 94.8,
+                                "contractSize": "REGULAR",
+                                "expiration": 1598590800,
+                                "lastTradeDate": 1597899600,
+                                "impliedVolatility": 1.642579912109375,
+                                "inTheMoney": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "error": null
+    }
+}


### PR DESCRIPTION
This branch contains a small refactor for cookie and crumb acquisition as well as the primary feature of a `getStockOptions` method.

I have been using this package for quite a while now and love it. I have been getting more into options and I would like to enhance my own personal trading info infra by adding onto this library. 

I tried my best to stick to the conventions laid out in the API/decoder and followed the formatting and checks as described in the CONTRIB. Hopefully it is up to standard.

If you have any recommendations or questions, please don't hesitate to comment.

Best,
Compo