### PR TITLE
Fix invalid return type for option exp_date

### DIFF
--- a/src/Results/Option.php
+++ b/src/Results/Option.php
@@ -32,7 +32,7 @@ class Option implements \JsonSerializable
         ];
     }
 
-    public function getExpirationDate(): int
+    public function getExpirationDate(): \DateTimeInterface
     {
         return $this->expirationDate;
     }


### PR DESCRIPTION
Hi @scheb !,

I recently added these options changes but found a small oversight with the `Option` results model `getExpirationDate()` return value.

Best,
CompoTypo