### PR TITLE
Check if column value is a null type when decoding historical data

### DIFF
--- a/src/ResultDecoder.php
+++ b/src/ResultDecoder.php
@@ -228,13 +228,13 @@ class ResultDecoder
 
         foreach (['open', 'high', 'low', 'close', 'volume'] as $column) {
             $columnValue = $json['indicators']['quote'][0][$column][$index];
-            if (!is_numeric($columnValue) && 'null' !== $columnValue) {
+            if (!is_numeric($columnValue) && 'null' !== $columnValue && !is_null($columnValue)) {
                 throw new ApiException(\sprintf('Not a number in column "%s": %s', $column, $column), ApiException::INVALID_VALUE);
             }
         }
 
         $columnValue = $json['indicators']['adjclose'][0]['adjclose'][$index];
-        if (!is_numeric($columnValue) && 'null' !== $columnValue) {
+        if (!is_numeric($columnValue) && 'null' !== $columnValue && !is_null($columnValue)) {
             throw new ApiException(\sprintf('Not a number in column "%s": %s', 'adjclose', 'adjclose'), ApiException::INVALID_VALUE);
         }
 

--- a/src/ResultDecoder.php
+++ b/src/ResultDecoder.php
@@ -228,13 +228,13 @@ class ResultDecoder
 
         foreach (['open', 'high', 'low', 'close', 'volume'] as $column) {
             $columnValue = $json['indicators']['quote'][0][$column][$index];
-            if (!is_numeric($columnValue) && 'null' !== $columnValue && !is_null($columnValue)) {
+            if (!is_numeric($columnValue) && 'null' !== $columnValue && !\is_null($columnValue)) {
                 throw new ApiException(\sprintf('Not a number in column "%s": %s', $column, $column), ApiException::INVALID_VALUE);
             }
         }
 
         $columnValue = $json['indicators']['adjclose'][0]['adjclose'][$index];
-        if (!is_numeric($columnValue) && 'null' !== $columnValue && !is_null($columnValue)) {
+        if (!is_numeric($columnValue) && 'null' !== $columnValue && !\is_null($columnValue)) {
             throw new ApiException(\sprintf('Not a number in column "%s": %s', 'adjclose', 'adjclose'), ApiException::INVALID_VALUE);
         }
 


### PR DESCRIPTION
**Description**

Looks like with the recent changes to historical data, we should also be validating if OHLC data is actually `null` vs. just a string with null. 

In addition to checking if the column value is a string of 'null', also check if the column value is actually `null`.

This resolves issues for some securities where there's missing data (e.g. WBRPOX):

<img width="760" alt="image" src="https://github.com/user-attachments/assets/217c6aa4-d70a-4cf9-9384-cc64dc9215d3" />


