### PR TITLE
Allow empty shortname in search results

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -39,7 +39,7 @@ class ApiClient
      *
      * @throws GuzzleException|ApiException
      */
-    public function search(string $searchTerm, string $locale = 'en-US', int $limit = 10, bool $filterOnError = false): array
+    public function search(string $searchTerm, string $locale = 'en-US', int $limit = 10): array
     {
         $url = 'https://query{queryServer}.finance.yahoo.com/v1/finance/search?'
             .'q='.urlencode($searchTerm)
@@ -49,7 +49,7 @@ class ApiClient
 
         $response = $this->contextManager->request('GET', $url);
 
-        return $this->resultDecoder->transformSearchResult((string) $response->getBody(), $filterOnError);
+        return $this->resultDecoder->transformSearchResult((string) $response->getBody());
     }
 
     /**
@@ -83,7 +83,8 @@ class ApiClient
         $responseBody = $this->getHistoricalDataResponse($symbol, self::INTERVAL_1_MONTH, $startDate, $endDate, self::FILTER_DIVIDENDS);
 
         $historicData = $this->resultDecoder->transformDividendDataResult($responseBody);
-        usort($historicData, fn (DividendData $a, DividendData $b): int => // Data is not necessary in order, so ensure ascending order by date
+        usort($historicData, fn (DividendData $a, DividendData $b): int =>
+            // Data is not necessary in order, so ensure ascending order by date
             $a->getDate() <=> $b->getDate());
 
         return $historicData;
@@ -103,7 +104,8 @@ class ApiClient
         $responseBody = $this->getHistoricalDataResponse($symbol, self::INTERVAL_1_MONTH, $startDate, $endDate, self::FILTER_SPLITS);
 
         $historicData = $this->resultDecoder->transformSplitDataResult($responseBody);
-        usort($historicData, fn (SplitData $a, SplitData $b): int => // Data is not necessary in order, so ensure ascending order by date
+        usort($historicData, fn (SplitData $a, SplitData $b): int =>
+            // Data is not necessary in order, so ensure ascending order by date
             $a->getDate() <=> $b->getDate());
 
         return $historicData;

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -39,7 +39,7 @@ class ApiClient
      *
      * @throws GuzzleException|ApiException
      */
-    public function search(string $searchTerm, string $locale = 'en-US', int $limit = 10): array
+    public function search(string $searchTerm, string $locale = 'en-US', int $limit = 10, bool $filterOnError = false): array
     {
         $url = 'https://query{queryServer}.finance.yahoo.com/v1/finance/search?'
             .'q='.urlencode($searchTerm)
@@ -49,7 +49,7 @@ class ApiClient
 
         $response = $this->contextManager->request('GET', $url);
 
-        return $this->resultDecoder->transformSearchResult((string) $response->getBody());
+        return $this->resultDecoder->transformSearchResult((string) $response->getBody(), $filterOnError);
     }
 
     /**
@@ -83,8 +83,7 @@ class ApiClient
         $responseBody = $this->getHistoricalDataResponse($symbol, self::INTERVAL_1_MONTH, $startDate, $endDate, self::FILTER_DIVIDENDS);
 
         $historicData = $this->resultDecoder->transformDividendDataResult($responseBody);
-        usort($historicData, fn (DividendData $a, DividendData $b): int =>
-            // Data is not necessary in order, so ensure ascending order by date
+        usort($historicData, fn (DividendData $a, DividendData $b): int => // Data is not necessary in order, so ensure ascending order by date
             $a->getDate() <=> $b->getDate());
 
         return $historicData;
@@ -104,8 +103,7 @@ class ApiClient
         $responseBody = $this->getHistoricalDataResponse($symbol, self::INTERVAL_1_MONTH, $startDate, $endDate, self::FILTER_SPLITS);
 
         $historicData = $this->resultDecoder->transformSplitDataResult($responseBody);
-        usort($historicData, fn (SplitData $a, SplitData $b): int =>
-            // Data is not necessary in order, so ensure ascending order by date
+        usort($historicData, fn (SplitData $a, SplitData $b): int => // Data is not necessary in order, so ensure ascending order by date
             $a->getDate() <=> $b->getDate());
 
         return $historicData;

--- a/src/ResultDecoder.php
+++ b/src/ResultDecoder.php
@@ -135,20 +135,26 @@ class ResultDecoder
     {
     }
 
-    public function transformSearchResult(string $responseBody): array
+    public function transformSearchResult(string $responseBody, bool $filterOnError = false): array
     {
         $decoded = json_decode($responseBody, true);
         if (!isset($decoded['quotes']) || !\is_array($decoded['quotes'])) {
             throw new ApiException('Yahoo Search API returned an invalid response', ApiException::INVALID_RESPONSE);
         }
 
-        return array_map(fn (array $item): SearchResult => $this->createSearchResultFromJson($item), $decoded['quotes']);
+        return array_filter(
+            array_map(fn (array $item): SearchResult|bool => $this->createSearchResultFromJson($item, $filterOnError), $decoded['quotes']),
+            fn (SearchResult|bool $result) => false !== $result,
+        );
     }
 
-    private function createSearchResultFromJson(array $json): SearchResult
+    private function createSearchResultFromJson(array $json, bool $filterOnError = false): SearchResult|bool
     {
         $missingFields = array_diff(self::SEARCH_RESULT_FIELDS, array_keys($json));
         if ([] !== $missingFields) {
+            if ($filterOnError) {
+                return false;
+            }
             throw new ApiException(\sprintf('Search result is missing fields: %s', implode(', ', $missingFields)), ApiException::INVALID_RESPONSE);
         }
 

--- a/src/ResultDecoder.php
+++ b/src/ResultDecoder.php
@@ -23,7 +23,7 @@ class ResultDecoder
     public const HISTORICAL_DATA_HEADER_LINE = ['Date', 'Open', 'High', 'Low', 'Close', 'Adj Close', 'Volume'];
     public const DIVIDEND_DATA_HEADER_LINE = ['Date', 'Dividends'];
     public const SPLIT_DATA_HEADER_LINE = ['Date', 'Stock Splits'];
-    public const SEARCH_RESULT_FIELDS = ['symbol', 'shortname', 'exchange', 'quoteType', 'exchDisp', 'typeDisp'];
+    public const SEARCH_RESULT_FIELDS = ['symbol', 'exchange', 'quoteType', 'exchDisp', 'typeDisp'];
 
     public const OPTION_CHAIN_FIELDS_MAP = [
         'underlyingSymbol' => ValueMapperInterface::TYPE_STRING,
@@ -135,32 +135,26 @@ class ResultDecoder
     {
     }
 
-    public function transformSearchResult(string $responseBody, bool $filterOnError = false): array
+    public function transformSearchResult(string $responseBody): array
     {
         $decoded = json_decode($responseBody, true);
         if (!isset($decoded['quotes']) || !\is_array($decoded['quotes'])) {
             throw new ApiException('Yahoo Search API returned an invalid response', ApiException::INVALID_RESPONSE);
         }
 
-        return array_filter(
-            array_map(fn (array $item): SearchResult|bool => $this->createSearchResultFromJson($item, $filterOnError), $decoded['quotes']),
-            fn (SearchResult|bool $result) => false !== $result,
-        );
+        return array_map(fn (array $item): SearchResult => $this->createSearchResultFromJson($item), $decoded['quotes']);
     }
 
-    private function createSearchResultFromJson(array $json, bool $filterOnError = false): SearchResult|bool
+    private function createSearchResultFromJson(array $json): SearchResult
     {
         $missingFields = array_diff(self::SEARCH_RESULT_FIELDS, array_keys($json));
         if ([] !== $missingFields) {
-            if ($filterOnError) {
-                return false;
-            }
             throw new ApiException(\sprintf('Search result is missing fields: %s', implode(', ', $missingFields)), ApiException::INVALID_RESPONSE);
         }
 
         return new SearchResult(
             $json['symbol'],
-            $json['shortname'],
+            $json['shortname'] ?? null,
             $json['exchange'],
             $json['quoteType'],
             $json['exchDisp'],

--- a/tests/Unit/ResultDecoderTest.php
+++ b/tests/Unit/ResultDecoderTest.php
@@ -515,55 +515,36 @@ class ResultDecoderTest extends TestCase
     }
 
     #[Test]
-    public function transformSearchResult_jsonWithMissedFieldAndFilterOnError_filterInvalidResults(): void
+    public function transformSearchResult_jsonWithoutShortname_createSearchResultWithNullShortname(): void
     {
         $jsonArray = [
             'quotes' => [
                 [
                     'symbol' => 'AAPL',
-                    'shortname' => 'Apple Inc.',
                     'exchange' => 'NMS',
                     'quoteType' => 'EQUITY',
                     'exchDisp' => 'NASDAQ',
                     'typeDisp' => 'Equity',
-                ],
-                ['shortname' => 'Invalid Item'], // Missing required fields
-                [
-                    'symbol' => 'GOOGL',
-                    'shortname' => 'Alphabet Inc.',
-                    'exchange' => 'NMS',
-                    'quoteType' => 'EQUITY',
-                    'exchDisp' => 'NASDAQ',
-                    'typeDisp' => 'Equity',
+                    // shortname is intentionally missing
                 ],
             ],
         ];
 
-        $returnedResult = $this->resultDecoder->transformSearchResult(json_encode($jsonArray), filterOnError: true);
+        $returnedResult = $this->resultDecoder->transformSearchResult(json_encode($jsonArray));
 
         $this->assertIsArray($returnedResult);
-        $this->assertCount(2, $returnedResult); // Only 2 valid results
+        $this->assertCount(1, $returnedResult);
         $this->assertContainsOnlyInstancesOf(SearchResult::class, $returnedResult);
 
-        $expectedFirstItem = new SearchResult(
+        $expectedItem = new SearchResult(
             'AAPL',
-            'Apple Inc.',
+            null, // shortname should be null
             'NMS',
             'EQUITY',
             'NASDAQ',
             'Equity'
         );
-        $this->assertEquals($expectedFirstItem, $returnedResult[0]);
-
-        $expectedSecondItem = new SearchResult(
-            'GOOGL',
-            'Alphabet Inc.',
-            'NMS',
-            'EQUITY',
-            'NASDAQ',
-            'Equity'
-        );
-        $this->assertEquals($expectedSecondItem, $returnedResult[2]);
+        $this->assertEquals($expectedItem, $returnedResult[0]);
     }
 
     #[Test]

--- a/tests/Unit/ResultDecoderTest.php
+++ b/tests/Unit/ResultDecoderTest.php
@@ -515,6 +515,58 @@ class ResultDecoderTest extends TestCase
     }
 
     #[Test]
+    public function transformSearchResult_jsonWithMissedFieldAndFilterOnError_filterInvalidResults(): void
+    {
+        $jsonArray = [
+            'quotes' => [
+                [
+                    'symbol' => 'AAPL',
+                    'shortname' => 'Apple Inc.',
+                    'exchange' => 'NMS',
+                    'quoteType' => 'EQUITY',
+                    'exchDisp' => 'NASDAQ',
+                    'typeDisp' => 'Equity',
+                ],
+                ['shortname' => 'Invalid Item'], // Missing required fields
+                [
+                    'symbol' => 'GOOGL',
+                    'shortname' => 'Alphabet Inc.',
+                    'exchange' => 'NMS',
+                    'quoteType' => 'EQUITY',
+                    'exchDisp' => 'NASDAQ',
+                    'typeDisp' => 'Equity',
+                ],
+            ],
+        ];
+
+        $returnedResult = $this->resultDecoder->transformSearchResult(json_encode($jsonArray), filterOnError: true);
+
+        $this->assertIsArray($returnedResult);
+        $this->assertCount(2, $returnedResult); // Only 2 valid results
+        $this->assertContainsOnlyInstancesOf(SearchResult::class, $returnedResult);
+
+        $expectedFirstItem = new SearchResult(
+            'AAPL',
+            'Apple Inc.',
+            'NMS',
+            'EQUITY',
+            'NASDAQ',
+            'Equity'
+        );
+        $this->assertEquals($expectedFirstItem, $returnedResult[0]);
+
+        $expectedSecondItem = new SearchResult(
+            'GOOGL',
+            'Alphabet Inc.',
+            'NMS',
+            'EQUITY',
+            'NASDAQ',
+            'Equity'
+        );
+        $this->assertEquals($expectedSecondItem, $returnedResult[2]);
+    }
+
+    #[Test]
     #[DataProvider('provideTransformQuotesInvalidResult')]
     public function transformOptionChains_jsonGiven_createArrayOfInvalidResult(array $responseBody): void
     {


### PR DESCRIPTION
**Description**
Some request failed because the api don't have required props. You can try 
```php
$searchResult = $client->search("apc");
$searchResult = $client->search("apc", filterOnError: true);
```
I add an option to not throw an error, it's backward compatible and allows users to choose whether they want to handle errors gracefully or let the library throw exceptions. When ⁠filterOnError is set to ⁠true, failed requests will return ⁠null or an empty result instead of throwing an exception, giving developers more control over error handling in their applications. Currently I return an empty array when there's an error whereas I could return some information.

 I hope this aligns with the library's vision.